### PR TITLE
MEM-43 gist copied from swagger with memverse api fromat instead of simplifiest gist

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -81,7 +81,7 @@ android {
     }
 
     flavorDimensions "default"
-    productFlavors { 
+    productFlavors {
         production {
             dimension "default"
             applicationIdSuffix ""
@@ -89,12 +89,13 @@ android {
         }
         staging {
             dimension "default"
-            applicationIdSuffix ".stg"
+            // applicationIdSuffix ".stg"
             manifestPlaceholders = [appName: "[STG] Memverse"]
         }
         development {
             dimension "default"
-            applicationIdSuffix ".dev"
+            //todo fix
+            // applicationIdSuffix ".dev"
             manifestPlaceholders = [appName: "[DEV] Memverse"]
         }
     }

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = NO;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/lib/src/features/verse/data/verse_repository.dart
+++ b/lib/src/features/verse/data/verse_repository.dart
@@ -41,7 +41,7 @@ class LiveVerseRepository implements VerseRepository {
 
   /// The URL to fetch Bible verses from
   static const String _apiUrl =
-      'https://gist.githubusercontent.com/neiljaywarner/2880b87250163386a41e00fc1535e02c/raw';
+      'https://gist.githubusercontent.com/neiljaywarner/0d875211cfc2478b0ffb295bc93916ab/raw/4df56fc9fa2c15bc276ff6de822794159ee154e9/show_memverses_2_verses.json';
 
   /// Get a list of verses from the remote API
   @override
@@ -52,14 +52,15 @@ class LiveVerseRepository implements VerseRepository {
 
       if (response.statusCode == 200) {
         // Convert string response to JSON if needed
-        List<dynamic> jsonList;
+        Map<String, dynamic> jsonData;
         if (response.data is String) {
-          jsonList = jsonDecode(response.data as String) as List<dynamic>;
+          jsonData = jsonDecode(response.data as String) as Map<String, dynamic>;
         } else {
-          jsonList = response.data as List<dynamic>;
+          jsonData = response.data as Map<String, dynamic>;
         }
 
-        final verses = _parseVerses(jsonList);
+        final versesList = jsonData['response'] as List<dynamic>;
+        final verses = _parseVerses(versesList);
         return verses;
       } else {
         // coverage:ignore-line
@@ -78,11 +79,13 @@ class LiveVerseRepository implements VerseRepository {
       try {
         // Handle dynamic access safely
         final json = item as Map<String, dynamic>;
+        final verseData = json['verse'] as Map<String, dynamic>;
 
-        final text = json['text'] as String? ?? 'No text available';
+        final text = verseData['text'] as String? ?? 'No text available';
         final reference = json['ref'] as String? ?? 'Unknown reference';
+        final translation = verseData['translation'] as String? ?? 'Unknown';
 
-        result.add(Verse(text: text, reference: reference));
+        result.add(Verse(text: text, reference: reference, translation: translation));
       } catch (e) {
         // Rethrow exceptions instead of skipping them
         rethrow;

--- a/test/verse_repository_test.dart
+++ b/test/verse_repository_test.dart
@@ -118,17 +118,25 @@ void main() {
       'getVerses should return verses from API when request succeeds with List response',
       () async {
         when(mockDio.get<dynamic>(any)).thenAnswer(
-          (_) async => Response<List<dynamic>>(
-            data: <Map<String, dynamic>>[
-              <String, dynamic>{
-                'ref': 'Col 1:17',
-                'text': 'He existed before anything else, and he holds all creation together',
-              },
-              <String, dynamic>{
-                'ref': 'Phil 4:13',
-                'text': 'For I can do everything through Christ, who gives me strength',
-              },
-            ],
+          (_) async => Response<Map<String, dynamic>>(
+            data: <String, dynamic>{
+              'response': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'ref': 'Col 1:17',
+                  'verse': <String, dynamic>{
+                    'text': 'He existed before anything else, and he holds all creation together',
+                    'translation': 'NLT',
+                  },
+                },
+                <String, dynamic>{
+                  'ref': 'Phil 4:13',
+                  'verse': <String, dynamic>{
+                    'text': 'For I can do everything through Christ, who gives me strength',
+                    'translation': 'NLT',
+                  },
+                },
+              ],
+            },
             statusCode: 200,
             requestOptions: RequestOptions(path: '/'),
           ),
@@ -144,16 +152,24 @@ void main() {
 
     test('getVerses should handle string response and parse JSON correctly', () async {
       const jsonString = '''
-      [
-        {
-          "ref": "Psalm 23:1",
-          "text": "The LORD is my shepherd; I have all that I need."
-        },
-        {
-          "ref": "Jer 29:11", 
-          "text": "For I know the plans I have for you, says the LORD."
-        }
-      ]
+      {
+        "response": [
+          {
+            "ref": "Psalm 23:1",
+            "verse": {
+              "text": "The LORD is my shepherd; I have all that I need.",
+              "translation": "NLT"
+            }
+          },
+          {
+            "ref": "Jer 29:11", 
+            "verse": {
+              "text": "For I know the plans I have for you, says the LORD.",
+              "translation": "NLT"
+            }
+          }
+        ]
+      }
       ''';
 
       when(mockDio.get<dynamic>(any)).thenAnswer(
@@ -193,11 +209,16 @@ void main() {
 
     test('_parseVerses handles missing or null JSON values', () async {
       when(mockDio.get<dynamic>(any)).thenAnswer(
-        (_) async => Response<List<dynamic>>(
-          data: <Map<String, dynamic>>[
-            <String, dynamic>{'ref': null, 'text': null},
-            <String, dynamic>{},
-          ],
+        (_) async => Response<Map<String, dynamic>>(
+          data: <String, dynamic>{
+            'response': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'ref': null,
+                'verse': <String, dynamic>{'text': null, 'translation': null},
+              },
+              <String, dynamic>{'verse': <String, dynamic>{}},
+            ],
+          },
           statusCode: 200,
           requestOptions: RequestOptions(path: '/'),
         ),
@@ -213,7 +234,7 @@ void main() {
     });
 
     test('getVerses with invalid JSON should throw', () async {
-      const jsonString = '["not a proper verse object"]';
+      const jsonString = '{"response": ["not a proper verse object"]}';
 
       when(mockDio.get<dynamic>(any)).thenAnswer(
         (_) async => Response<String>(
@@ -228,8 +249,10 @@ void main() {
 
     test('getVerses with malformed json during parsing should throw', () async {
       when(mockDio.get<dynamic>(any)).thenAnswer(
-        (_) async => Response<List<dynamic>>(
-          data: <dynamic>[42],
+        (_) async => Response<Map<String, dynamic>>(
+          data: <String, dynamic>{
+            'response': <dynamic>[42],
+          },
           statusCode: 200,
           requestOptions: RequestOptions(path: '/'),
         ),


### PR DESCRIPTION
Direct results from the prompt "can you please switch from the existing gist to use https://gist.githubusercontent.com/neiljaywarner/0d875211cfc2478b0ffb295bc93916ab/raw/4df56fc9fa2c15bc276ff6de822794159ee154e9/show_memverses_2_verses.json" -to the dart code which does work


## Description

Wow, this is incredible, no manual changes to dart code if i recall, just gave it the new URL and it modified tests. the android change was temporary because of @TheophilusOjukwuII 's work in progress.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced verse content now includes translations, offering richer information to users.
  
- **Chores**
	- Updated mobile platform configurations and initialization settings on both Android and iOS to ensure better compatibility and future-readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->