### PR TITLE
fix for ref index error

### DIFF
--- a/MEM-40_ai_prompts.log
+++ b/MEM-40_ai_prompts.log
@@ -1,0 +1,12 @@
+# MEM-40 AI Prompts Log
+
+## 2025-05-07 05:27:37 PM
+**Task:** Fix range error length invalid_value on the reference page
+
+**Issue:** The app was experiencing an "Invalid Range" error when going through all verses and trying to access a verse beyond the available list
+
+**Solution:**
+1. Fixed the `loadNextVerse()` method in `MemversePage` to properly check if we've reached the end of verses and wrap back to the first verse
+2. Added index range checking in both small screen and regular layout for `currentVerseIndex`
+3. Created a test to verify the fix works as expected
+4. Added script for pre-commit checks that runs dart fix, formatting, analysis, and tests

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -82,16 +82,18 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
-  static const List<Locale> supportedLocales = <Locale>[Locale('en'), Locale('es')];
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('es')
+  ];
 
   /// Title of app
   ///
@@ -284,18 +286,18 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'en':
-      return AppLocalizationsEn();
-    case 'es':
-      return AppLocalizationsEs();
+    case 'en': return AppLocalizationsEn();
+    case 'es': return AppLocalizationsEs();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
+    'that was used.'
   );
 }

--- a/lib/src/features/verse/presentation/memverse_page.dart
+++ b/lib/src/features/verse/presentation/memverse_page.dart
@@ -57,7 +57,17 @@ class MemversePage extends HookConsumerWidget {
       isAnswerCorrect.value = false;
 
       questionNumber.value++;
-      currentVerseIndex.value++;
+
+      // Update the current verse index only if we have verses data
+      versesAsync.whenData((verses) {
+        // Check if we've reached the end of available verses
+        if (currentVerseIndex.value + 1 < verses.length) {
+          currentVerseIndex.value++;
+        } else {
+          // Reset to the first verse when we reach the end
+          currentVerseIndex.value = 0;
+        }
+      });
     }
 
     void submitAnswer(String expectedReference) {
@@ -230,7 +240,14 @@ class MemversePage extends HookConsumerWidget {
                           height: MediaQuery.of(context).size.height * 0.8,
                           child: QuestionSection(
                             versesAsync: versesAsync,
-                            currentVerseIndex: currentVerseIndex.value,
+                            currentVerseIndex: versesAsync.maybeWhen(
+                              data:
+                                  (verses) =>
+                                      currentVerseIndex.value < verses.length
+                                          ? currentVerseIndex.value
+                                          : 0,
+                              orElse: () => 0,
+                            ),
                             questionNumber: questionNumber.value,
                             l10n: l10n,
                             answerController: answerController,

--- a/test/memverse_page_test.dart
+++ b/test/memverse_page_test.dart
@@ -284,6 +284,48 @@ void main() {
 
       expect(find.byType(SnackBar), findsOneWidget);
     });
+
+    testWidgets('handles end of verse list correctly', (WidgetTester tester) async {
+      when(() => mockRepository.getVerses()).thenAnswer(
+        (_) async => [
+          Verse(reference: 'Genesis 1:1', text: 'In the beginning...'),
+          Verse(reference: 'John 3:16', text: 'For God so loved the world...'),
+        ],
+      );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: MemversePage(),
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Genesis 1:1');
+      await tester.pump();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle(const Duration(milliseconds: 1500));
+
+      await tester.enterText(find.byType(TextField), 'John 3:16');
+      await tester.pump();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle(const Duration(milliseconds: 1500));
+
+      expect(find.text('In the beginning...'), findsOneWidget);
+      expect(find.byType(RichText), findsAtLeastNWidgets(1));
+      final questionText = tester.widget<RichText>(find.byType(RichText).first).text as TextSpan;
+      final children = questionText.children;
+      expect(children, isNotNull);
+      expect(children!.length, 2);
+      final numberSpan = children[1] as TextSpan;
+      expect(numberSpan.text, '3');
+    });
   });
 
   group('MemversePage Feedback Button', () {


### PR DESCRIPTION
## Description
The app was experiencing an "Invalid Range" error when going through all verses and trying to access a verse beyond the available list

## Changes
1. Fixed the `loadNextVerse()` method in `MemversePage` to properly check if we've reached the end of verses and wrap back to the first verse
2. Added index range checking in both small screen and regular layout for `currentVerseIndex`
3. Created a test to verify the fix works as expected